### PR TITLE
ci(lint-staged): add --allow-empty flag to lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
 	},
 	"scripts": {
 		"lint": "eslint .",
-		"precommit": "lint-staged",
+		"precommit": "lint-staged --allow-empty",
 		"pretest": "npm run lint",
 		"test": "node ./test/runTest.js"
 	},


### PR DESCRIPTION
Lint-staged will currently throw an error on adding files with an "empty" commit after prettier
--fix so we allow empty commits to prevent issues committing in this event